### PR TITLE
Fix: expected list has more items

### DIFF
--- a/smalldiff/main.py
+++ b/smalldiff/main.py
@@ -116,13 +116,24 @@ class SmallDiff:
             elif expected_val != actual_val:
                 diff[f"{path}.{i}" if path else i] = {"expected": expected_val, "actual": actual_val}
 
-        # Check if the actual list has more elements than the expected list
-        # If true, add the extra elements to the diff dictionary
+        # Check list items inequality
+        cls.__compare_remaining_list_items(expected, actual, diff, path)
+
+        return diff
+
+    @classmethod
+    def __compare_remaining_list_items(cls, expected: list, actual: list, diff: dict, path: str):
+
+        # Check if actual has more items than expected
         if len(actual) > len(expected):
             for j in range(len(expected), len(actual)):
                 diff[f"{path}.{j}" if path else j] = {"expected": None, "actual": actual[j]}
 
-        return diff
+        # Check if expected has more items than actual
+        if len(expected) > len(actual):
+            for j in range(len(actual), len(expected)):
+                diff[f"{path}.{j}" if path else j] = {"expected": expected[j], "actual": None}
+
 
     @classmethod
     def __print_diff(cls, diff: dict):

--- a/tests/test_smalldiff.py
+++ b/tests/test_smalldiff.py
@@ -194,6 +194,57 @@ class TestSmallDiff(unittest.TestCase):
 
         assert not SmallDiff.is_equal(data_expected, data_actual)
 
+    def test_nested_persons_length_unequal_1(self):
+        """
+        Test case for testing nested person lists unequal.
+        in this case Expected nested length has more items than the Actual
+        """
+        data_expected: dict[str, List[PersonModel]] = {
+            "1227": [
+                PersonModel(
+                    name="John Doe",
+                    age=28,
+                    gender=Gender.M,
+                    address=AddressModel(street="123 Main St.", dist="Dhaka", zip=1227)
+                ),
+                PersonModel(
+                    name="Rob Chapman",
+                    age=28,
+                    gender=Gender.M,
+                    address=AddressModel(street="123 Main St.", dist="Dhaka", zip=1227)
+                )
+            ],
+            "1229": [
+                PersonModel(
+                    name="Eric Clapton",
+                    age=28,
+                    gender=Gender.M,
+                    address=AddressModel(street="123 Main St.", dist="Dhaka", zip=1229)
+                )
+            ],
+        }
+
+        data_actual: dict[str, List[PersonModel]] = {
+            "1227": [
+                PersonModel(
+                    name="John Doe",
+                    age=28,
+                    gender=Gender.M,
+                    address=AddressModel(street="123 Main St.", dist="Dhaka", zip=1227)
+                )
+            ],
+            "1229": [
+                PersonModel(
+                    name="Eric Clapton",
+                    age=28,
+                    gender=Gender.M,
+                    address=AddressModel(street="123 Main St.", dist="Dhaka", zip=1229)
+                )
+            ]
+        }
+
+        assert not SmallDiff.is_equal(data_expected, data_actual)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Fixed when an expected nested list has more items than an actual nested list.
Example: 
`expected`
```json
{
    "KEY_1": ["item_1", "item_2"]
}
```
`actual`
```json
{
    "KEY_1": ["item_1"]
}
```
`output`
```json
{
    "KEY_1.1": {
        "expected": "item_2",
        "actual": null
    }
}
```


## Changes
- Bug Fixed
- Test case added

## Tested
- [x] YES
- [ ] NO